### PR TITLE
docs(email-import): document supported attachment types (PDF, TIFF, XML, EDI)

### DIFF
--- a/readme/end-user-and-partner-section/end-user-section/how-to-import-documents/email/README.md
+++ b/readme/end-user-and-partner-section/end-user-section/how-to-import-documents/email/README.md
@@ -20,3 +20,25 @@ After pressing NEW, the following menu will be shown to you.
 Here you can select which Protocol you would like.
 
 <figure><img src="../../../../.gitbook/assets/email4.png" alt="" width="207"><figcaption></figcaption></figure>
+
+## Supported attachment types
+
+DocBits imports the following document attachments from incoming emails:
+
+| Type | File extensions | Used for |
+| --- | --- | --- |
+| **PDF** | `.pdf` | Invoices, delivery notes, scanned documents |
+| **TIFF** | `.tif`, `.tiff` | Scanned / faxed documents |
+| **XML** | `.xml` | Structured e-invoices (e.g. ZUGFeRD/Factur-X, XRechning, Peppol) |
+| **EDI** | – | Electronic Data Interchange messages |
+
+{% hint style="info" %}
+If a forwarding gateway re-labels a document as `application/octet-stream`, DocBits still detects it from the file content and extension, and `.eml` emails are unpacked so an inner PDF/XML is imported.
+{% endhint %}
+
+Other attachments are **not** imported:
+
+* Images such as PNG, JPG, GIF or BMP — inline images (email signatures, logos) in forwarded mails are ignored automatically and never counted as failures.
+* Office files (Word, Excel, PowerPoint) and other non-document formats.
+
+If an email arrives without a supported attachment, and sender notification is enabled, the sender receives an email explaining that the document could not be imported, together with a link back to this page.


### PR DESCRIPTION
Adds a **Supported attachment types** section to the email import page: PDF, TIFF, XML, EDI, what is ignored (inline images, Office files), and octet-stream/.eml handling.

This is the page the inbound import-failure email now links to ("View supported attachments" button, DocBits_Email_Import #306).

Note: per the docs convention, the translation pages (de, es, fr, it, nl, pl, pt, tr, rs) should get the same section — can follow up.

https://claude.ai/code/session_01Lm7GERe3erua81DzS3uFo3