### PR TITLE
docs(release-notes): 14–23 July page becomes 14–29 July, refreshed to shipping versions

### DIFF
--- a/readme/SUMMARY.md
+++ b/readme/SUMMARY.md
@@ -18,7 +18,7 @@
   * [Hotfixes 30 June – 3 July 2026](overview-and-basics/release-notes/incremental-updates-30-june-3-july-2026.md)
   * [Hotfixes 3–4 July 2026](overview-and-basics/release-notes/incremental-updates-3-4-july-2026.md)
   * [Hotfixes 4–14 July 2026](overview-and-basics/release-notes/incremental-updates-4-14-july-2026.md)
-  * [Hotfixes 14–23 July 2026](overview-and-basics/release-notes/incremental-updates-14-23-july-2026.md)
+  * [Hotfixes 14–29 July 2026](overview-and-basics/release-notes/incremental-updates-14-29-july-2026.md)
 * [FAQ](overview-and-basics/faq/README.md)
   * [General Information](overview-and-basics/faq/general-information.md)
   * [Document Processing](overview-and-basics/faq/document-processing/README.md)

--- a/readme/overview-and-basics/release-notes/README.md
+++ b/readme/overview-and-basics/release-notes/README.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-> **Latest hotfix release:** [Hotfixes 14–23 July 2026](incremental-updates-14-23-july-2026.md): what changed in the 23 July 2026 production upgrade, from support tickets on error records to region-correct inbound e-mail. All hotfix pages are listed in the navigation under Release Notes.
+> **Latest hotfix release:** [Hotfixes 14–29 July 2026](incremental-updates-14-29-july-2026.md): what changed in the 29 July 2026 production upgrade, from two-factor authentication to region-correct inbound e-mail. All hotfix pages are listed in the navigation under Release Notes.
 
 ## **Release R1.0 13/14 June 2026**
 

--- a/readme/overview-and-basics/release-notes/incremental-updates-14-29-july-2026.md
+++ b/readme/overview-and-basics/release-notes/incremental-updates-14-29-july-2026.md
@@ -1,6 +1,6 @@
-# DocBits Release Notes — 14–23 July 2026
+# DocBits Release Notes — 14–29 July 2026
 
-_What changed in the DocBits production upgrade on 23 July 2026 (the Nova
+_What changed in the DocBits production upgrade on 29 July 2026 (the Nova
 channel update), covering everything since the 14 July release. Each service
 lists the version now live, then what's new or fixed in plain language.
 Services not listed had no customer-facing changes._
@@ -9,6 +9,13 @@ Services not listed had no customer-facing changes._
 
 ## Highlights
 
+- **Two-factor authentication.** DocBits accounts can now be protected with a
+  second factor: an authenticator app (TOTP), a one-time code by e-mail, or a
+  passkey via Touch ID, Windows Hello, YubiKey and similar. Backup codes cover
+  the case of a lost device, and a trusted device can skip the second factor
+  for a while. Every user can switch it on for themselves; administrators can
+  require it for the whole organisation. See the
+  [Two-Factor Authentication guide](../two-factor-authentication.md).
 - **Support tickets from the error screen.** When something goes wrong, you can
   now open a support ticket directly from the error record. The ticket already
   contains the technical context, so you don't have to describe it.
@@ -23,15 +30,25 @@ Services not listed had no customer-facing changes._
 - **Tax code mapping for e-documents.** A new settings page maps your ERP tax
   codes for electronic documents, and exports check the mapping up front
   instead of failing in the ERP.
-- **Script changes are password-protected.** Custom scripts can change how
-  documents are processed, so every script edit now requires a password that
-  rotates hourly. Ask your administrator for the current one.
 - **Turbo AI tier retired.** The Turbo model has reached end of life. Anyone
   who had it selected was moved to Fast automatically; no action needed.
 
 ---
 
-## Web App — live: `10.45.1`
+## Web App — live: `10.46.2`
+
+### Signing in
+
+- **Two-factor authentication:** set up an authenticator app, e-mail codes or a
+  passkey under your profile, print backup codes, and mark a device as trusted
+  so it doesn't ask every time. Passkey users can sign in without a password
+  entirely. Organisation admins get an enforcement switch and an adoption
+  overview showing who has enrolled.
+- **Deleted accounts:** logging in with a deleted account says so instead of
+  failing with a generic error.
+- **SSO:** fixed an error when signing in while a different region was
+  selected. SSO sessions now expire when the identity provider says they do,
+  not on a fixed local timer.
 
 ### Working with documents
 
@@ -39,47 +56,52 @@ Services not listed had no customer-facing changes._
   shows a proper message instead of script errors.
 - **Field Validation:** the page-number input is wider and jumps to the page
   on Enter. A field made read-only by a script still shows its field
-  connection.
+  connection. A warning popup that printed raw JavaScript now shows the actual
+  message, and the screen no longer freezes on documents with long e-document
+  line-item tables.
 - **Table extraction:** deleting a column frees its name for re-use, and
   deleted headers no longer reappear in the saved table.
-- **Approvals:** users can no longer approve a Sales Tax step their group has
-  no permission for, and the approval history shows all entries again. The
+- **Approvals:** opening a freshly pending document lands on the right approval
+  screen. Users can no longer approve a Sales Tax step their group has no
+  permission for, and the approval history shows all entries again. The
   history also names the person who actually approved, including approvals an
   admin made on behalf of the assignee.
 - **Suppliers:** the Accounting page no longer shows a false "Supplier is
   missing" warning, and deleting a supplier that only exists from extraction
   no longer leaves the dialog hanging.
-- **Tasks and notifications:** the delete option is hidden from users without
-  admin rights.
+- **Master data:** tables on the master data page scroll again.
+- **Tasks and notifications:** deleting a task is no longer admin-only. Whether
+  non-admins may delete their own tasks is now an organisation setting, and
+  users who have a task on a document they can't open get a task-only view
+  instead of an error.
 
 ### Dashboard and search
 
 - **Export:** exports use the dashboard you have selected, and the app warns
   you before exporting a dashboard with unsaved changes.
 - **Search:** Invoice Type is available as a search field with its list of
-  values.
+  values. When a result set is larger than the window the dashboard can show,
+  the count badge now says so instead of quietly truncating.
 - **Import log:** split documents can be found via their parent document, and
   the Failed Filenames column lists only files that actually failed or were
   skipped.
-
-### Sign-in
-
-- **Deleted accounts:** logging in with a deleted account says so instead of
-  failing with a generic error.
-- **SSO:** fixed an error when signing in while a different region was
-  selected.
 
 ### Settings and administration
 
 - **Support tickets:** create a ticket straight from an error record. Tickets
   carry the environment and release channel, and the screenshot capture no
   longer hangs.
+- **Groups and permissions:** unclassified documents can be granted as a
+  permission like any other document type.
 - **Workflow Builder:** newly created or renamed cards, e-mail templates and
   other dropdown items appear immediately, without reloading the page.
+- **Decision Trees:** document field labels in the designer follow the
+  interface language instead of always showing the English name.
 - **Document Types:** new Structured Extraction setting in the extraction
   section.
 - **E-Doc tax codes:** new settings page to map your ERP tax codes for
   electronic documents (see Highlights).
+- **Auto Accounting:** dimensions show reliably instead of intermittently.
 - **AI model selection:** the retired Turbo tier is gone from the dropdown;
   existing selections show Fast.
 - **Service Versions dialog:** now scrollable, includes the Auth Bridge
@@ -94,29 +116,35 @@ misaligned checkboxes in field settings are aligned again, blocked document
 deletions explain why, and E-Document settings handle switching from Default
 to Custom cleanly.
 
-## API Service — live: `12.64.3`
+## API Service — live: `12.68.1`
 
-- **Script security:** script changes require a time-based password
-  (see Highlights).
+- **Two-factor authentication:** all password-based login paths run through the
+  second-factor check, so no integration route bypasses it.
 - **E-Doc tax codes:** ERP tax-code mapping for electronic documents, with a
   central check before export so missing codes surface early.
 - **Access control:** admins can grant non-admin users visibility of
   unclassified documents.
+- **Deletion audit trail:** documents record who deleted them and when.
 - **Personal dashboards:** fixed sharing settings that wouldn't save.
 - **Dashboard search:** Invoice Type joins the extended search fields, and
   documents created by a barcode or QR split are found via their parent
   document.
+- **Dashboard freshness:** refreshing a table or reprocessing a document clears
+  the dashboard cache, so the list no longer shows the pre-change values.
 - **Uploads:** repeated uploads of the same file during a network retry no
   longer create duplicate documents.
 - **Supplier lookup:** results arrive as soon as the data is ready instead of
   after a fixed wait.
 - **Infor export:** unit prices keep four decimal places. M3 exports can
   include zero-amount line charges, and negative LN cost lines are sent as
-  positive credits.
+  positive credits. Export also waits for a pending workflow to finish instead
+  of running mid-workflow.
 - **Approvals:** an approval is only linked to an approval request when the
-  approver is its assignee.
+  approver is its assignee. Changes a workflow made on its own are attributed
+  to the System user rather than to the last person who touched the document.
 - **Login stability:** a temporary failure inside token validation no longer
-  logs users out; the app retries instead.
+  logs users out; the app retries instead. Documents get the same treatment and
+  no longer fail outright on a brief auth hiccup.
 - **Classification:** source rules now match against every document source
   field, not fixed positions.
 - **Validation stability:** a field without a name no longer crashes document
@@ -124,9 +152,17 @@ to Custom cleanly.
 - **AI models:** the Turbo tier (retired) is remapped to Fast everywhere,
   including fine-tuned variants, with a guard so a retired model can never
   run.
+- **Background jobs:** a wedged scheduler is detected and restarted, so
+  recurring jobs can't silently stop.
 
-## Auth Service — live: `1.72.8`
+## Auth Service — live: `1.75.3`
 
+- **Two-factor authentication:** the backend behind the Highlights entry.
+  Authenticator apps, e-mail one-time codes, passkeys and trusted devices, plus
+  backup codes, per-organisation enforcement and passwordless passkey login.
+  Enrolling signs out your other sessions, changing your password revokes
+  trusted devices, and the verify endpoints are rate-limited with lockout and a
+  replay guard against reused codes.
 - **Login history:** sign-ins via SSO/SAML now appear in the login history,
   and the last-login timestamp is stamped reliably for every login type.
   Viewing another user's login history requires the appropriate admin level.
@@ -142,7 +178,8 @@ to Custom cleanly.
   clean "expired" response, organisations without a SAML configuration get a
   proper not-found answer instead of a wrong login flow, logout always
   completes even when the sign-out request can't be verified, and several
-  crashes around missing identity-provider configuration are gone.
+  crashes around missing identity-provider configuration are gone. The token
+  lifetime the provider returns is passed on to the app.
 - **Session tokens:** fixed short-lived session tokens being rejected as
   invalid even though they weren't expired.
 - **Management tooling:** organisation region is visible in the management
@@ -150,7 +187,7 @@ to Custom cleanly.
   usage administration gained dedicated endpoints. These changes affect
   DocBits staff tooling, not the customer app.
 
-## Email Service — live: `1.39.9`
+## Email Service — live: `1.40.2`
 
 - **Region-correct import:** inbound e-mail domains exist per region, and
   mails arriving in the wrong region are forwarded to the right one. US
@@ -159,63 +196,80 @@ to Custom cleanly.
   Instance selection, fixing O365 imports for US customers. An invalid tenant
   now produces a clear login error instead of a server error, and incomplete
   tenant credentials fail immediately with a message rather than silently.
+- **Connection test:** testing an IMAP mailbox that doesn't answer fails with a
+  timeout message after a few seconds instead of running into a gateway
+  timeout.
 - **Inbox hygiene:** e-mails without attachments are moved out of the inbox
   instead of piling up.
 - **No duplicates on retry:** uploads to the document API carry an idempotency
   key, so a retried delivery can't create the same document twice.
 - **Source naming:** O365 sources with a folder configured include the account
-  e-mail in their name, so similar sources are distinguishable.
+  e-mail in their name, so similar sources are distinguishable. The mailbox
+  address is read from the authenticated account rather than a typed-in field.
 - **Import log housekeeping:** import log entries are kept for 90 days and
   cleaned up automatically after that.
 
-## PO Match Service — live: `1.59.1`
+## PO Match Service — live: `1.59.3`
 
 - **"Table incomplete" status:** invoices whose line-item table couldn't be
   mapped get their own status instead of the misleading "purchase order not
   found" (see Highlights). The dashboard shows it with the not-matched icon.
 - **Better error detail:** table-mapping failures name the specific column
   that didn't map.
+- **Faster on large invoices:** rules-based matching groups candidates by item
+  number and reads the tolerance settings once per organisation instead of once
+  per line.
 - **Cleaner API behaviour:** requests for PO rules that don't exist return a
   proper not-found answer, and corrupt cache entries are dropped instead of
   causing repeated errors.
 - **Match on total:** fixed a bug in matching against the purchase-order
   total.
 
-## Fulltext Service — live: `1.38.3`
+## Fulltext Service — live: `1.39.1`
 
 - **European number formats:** amounts written with a decimal comma
   (`1.234,56`) are normalised before indexing, so amount searches and filters
   work regardless of number format.
+- **Honest result counts:** when a search matches more documents than the
+  dashboard window returns, the response says so instead of presenting a
+  truncated list as complete.
 - **ERP counts:** fixed a token error that could interrupt the live count
   stream on the dashboard.
 - **Indexing resilience:** indexing now rides out temporary database and
   auth-service hiccups (automatic retry, fallback to the primary database)
   and discards malformed queue messages instead of retrying them forever.
 
-## OCR Service — live: `1.9.9`
+## OCR Service — live: `1.10.3`
 
+- **Stable reading order:** text is read in a deterministic order, so the same
+  document extracts the same way every time.
 - **Large documents:** the OCR time budget scales with document size, so very
   large files no longer fail with a timeout.
 - **Unusual characters:** a sanitizer cleans characters the OCR engine can't
   represent, fixing failures on documents with exotic symbols.
 - **Fewer transient failures:** temporary storage connection errors are
-  retried automatically.
+  retried automatically, and a stalled worker is detected by whether it is
+  actually consuming work.
 
-## Extraction Service — live: `1.52.0`
+## Extraction Service — live: `1.53.3`
 
 - **Zero-tax US invoices:** fixed a case where the correct net/tax pair was
   dropped when the tax amount is zero.
 - **Table extraction:** tables stay editable when the configured mapping
   expects more columns than the document provides, and a crash on unusual row
   data is fixed.
+- **Stable reading order:** mirrors the OCR change above, so extraction sees
+  the same token order the OCR produced.
 - **AI models:** Turbo tier retirement, mirrored from the API Service.
 
-## Docflow Service — live: `2.7.2`
+## Docflow Service — live: `2.7.3`
 
 - **PO matching in workflows:** missing comparison values are treated as
   missing data rather than a mismatch.
 - **Order confirmation cards:** buyer and responsible person are resolved
   reliably.
+- **Quote cards:** the log now records when a quoted price exists but falls
+  outside the allowed date range, which used to look like missing data.
 - **Freight charges:** when neither side has charges, the case is resolved by
   the operator card instead of stalling.
 - **Security:** workflow API tokens are validated against the organisation
@@ -224,7 +278,7 @@ to Custom cleanly.
   background workers restart cleanly instead of leaving stalled processes
   behind.
 
-## Barcode Service — live: `1.17.4`
+## Barcode Service — live: `1.18.1`
 
 - **Long-running splits:** the connection to the task queue is kept alive
   during long barcode jobs, so splitting large batches no longer stalls near
@@ -235,18 +289,31 @@ to Custom cleanly.
 - **Import log housekeeping:** same 90-day retention and cleanup as the Email
   Service.
 
+## Auth Bridge Service — live: `0.4.1`
+
+- **Accurate replication alerts:** the EU/US account replication bridge
+  measures a stall from the last real progress rather than the first error, and
+  counts only genuine replication motion as progress. The nightly false "bridge
+  stalled" alerts are gone. Nothing changes in the app.
+
+## Operator Service — live: `1.42.1`
+
+- **Worker stability:** a stalled worker is detected by whether it is consuming
+  work, and idle chatter between workers is switched off.
+
 ---
 
 ## Unchanged in this release
 
-**Auth Bridge** (`0.3.6`), **Auto Accounting** (`1.20.1`), **Docnet**
-(`1.55.1`), **Operator** (`1.40.2`) and **Ideas** (`0.3.1`) carry no changes
-in this window.
+**Auto Accounting** (`1.21.1`) was rebuilt with no customer-facing changes.
+**Docnet** (`1.55.1`) and **Ideas** (`0.3.1`) carry no changes in this window.
 
-<!-- Generated by the docbits-changelog skill (version-boundary mode), then
-     reconciled on 23 Jul 2026 against the Nova versions actually deployed
-     (Web App 10.45.1, API 12.64.3, Auth 1.72.8, Email 1.39.9, PO Match
-     1.59.1, OCR 1.9.9, Docflow 2.7.2, FTP 1.31.2). Manage Layouts and
-     Custom Validation Rules were removed from this page: DOCB-13719 gated
-     both behind a beta query parameter, so they are not generally available
-     in 10.45.1. -->
+<!-- Generated by the docbits-changelog skill. Boundary: versions live in the
+     prod namespace on 28 Jul 2026 (Web App 10.41.8, API 12.57.8, Auth 1.71.1)
+     up to the versions live in the sandbox namespace the same day, which is
+     what the 29 July upgrade promotes. Re-check the version headers on the
+     morning of the upgrade in case anything else lands on sandbox first.
+     Manage Layouts and Custom Validation Rules stay excluded: DOCB-13719 gates
+     both behind a beta query parameter, so they are not generally available in
+     10.46.2. The hourly password for script changes (DOCB-13673) was added and
+     then reverted inside this window, so it must not be announced. -->


### PR DESCRIPTION
The 23 July production upgrade never happened. Prod still runs the 14 July build (Web App `10.41.8`, built 2026-07-14; API `12.57.8`; Auth `1.71.1`). The upgrade is now scheduled for 29 July, so this page is renamed and regenerated against the versions currently on sandbox, which is what the upgrade promotes.

### Slug change

`incremental-updates-14-23-july-2026.md` → `incremental-updates-14-29-july-2026.md`, with `SUMMARY.md` and the Release Notes landing page updated. The old public URL will 404 unless GitBook gets a redirect.

### Version headers

| Service | was on the page | now |
|---|---|---|
| Web App | 10.45.1 | `10.46.2` |
| API | 12.64.3 | `12.68.1` |
| Auth | 1.72.8 | `1.75.3` |
| Email | 1.39.9 | `1.40.2` |
| PO Match | 1.59.1 | `1.59.3` |
| Fulltext | 1.38.3 | `1.39.1` |
| OCR | 1.9.9 | `1.10.3` |
| Extraction | 1.52.0 | `1.53.3` |
| Docflow | 2.7.2 | `2.7.3` |
| Barcode | 1.17.4 | `1.18.1` |
| Auth Bridge | unchanged 0.3.6 | `0.4.1` |
| Operator | unchanged 1.40.2 | `1.42.1` |
| Auto Accounting | unchanged 1.20.1 | `1.21.1`, no customer-facing change |

### Content

- Two-Factor Authentication added as the lead highlight, with Web App and Auth Service detail, linking the existing 2FA guide.
- The "script changes are password-protected" highlight is removed. DOCB-13673 was added and then reverted inside this window, so the old page announced a feature that does not exist.
- New sections for Auth Bridge and Operator, which are no longer unchanged.
- Changes made between 23 and 28 July: approval screen routing, raw-JavaScript warning popup, master data scrolling, org-configurable task deletion, truncated-result count badge, unclassified-document permissions, SSO session lifetime, IMAP connect timeout, faster PO matching on large invoices, deterministic OCR reading order.
- Manage Layouts and Custom Validation Rules stay excluded, still beta-gated.

Boundary for the regeneration was the prod namespace versions on 28 July up to the sandbox namespace versions the same day: 510 commits across 14 repos.

Translations for the nine language branches follow separately.

https://claude.ai/code/session_01JmJ2sxByGb9VAHjbpAKjRf